### PR TITLE
Fix bug when getting SIR data (closes #41)

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,7 +53,7 @@ function get_sir_from_index(population, dataset, index) {
     // infectious
     sir[2] = data.confirmed;
     // removed
-    sir[3] = data.recovered;
+    sir[3] = data.recovered + data.deaths;
     return sir;
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -125,7 +125,7 @@ describe("get_sir_from_index", async function() {
         expect(sir[0]).to.be.equal("2020-1-25");
         expect(sir[1]).to.be.equal(pop-10-12);
         expect(sir[2]).to.be.equal(10);
-        expect(sir[3]).to.be.equal(12);
+        expect(sir[3]).to.be.equal(12+11);
     });
     it("return [\"\",-1,-1,-1] from a population of wrong type", async function() {
         var sir = main.get_sir_from_index("population string", dataset, 1);


### PR DESCRIPTION
We now take deaths into account in the "removed" data.